### PR TITLE
Front end v6.sf

### DIFF
--- a/docs/conversion.js
+++ b/docs/conversion.js
@@ -8,9 +8,9 @@ function methadoneMEQ(dose) {
 }
 
 // Function to safely parse float and default to zero if NaN
-function safeParseFloat(value) {
+function safeParseFloat(value, defaultValue = 0) {
     const parsed = parseFloat(value);
-    return isNaN(parsed) ? 0 : parsed;
+    return isNaN(parsed) ? defaultValue : parsed;
 }
 
 function resetInputs() {
@@ -35,7 +35,11 @@ function updateMorphineEquivalence() {
     let fentanyl = safeParseFloat(document.getElementById('fentanyl').value);
     let oxycodone = safeParseFloat(document.getElementById('oxycodone').value);
     let SfentanylPts = safeParseFloat(document.getElementById('SfentanylPts').value);
-    let SfentanylPct = safeParseFloat(document.getElementById('SfentanylPct').value);
+    let SfentanylPct = safeParseFloat(document.getElementById('SfentanylPct').value, 4); // Default to 4%
+
+    // Log values for debugging
+    console.log('SfentanylPts:', SfentanylPts);
+    console.log('SfentanylPct:', SfentanylPct);
 
     // Conversion calculations for each drug, rounded to nearest whole number
     let m0 = Math.round(hmo * 4) + ' mg';
@@ -65,10 +69,8 @@ function updateMorphineEquivalence() {
     document.getElementById('totalMorphine').textContent = totalMorphine + ' mg'; // Display as whole number
 }
 
-
 // Initialization and event listeners
 document.querySelectorAll('input[type="number"]').forEach(input => {
     input.addEventListener('input', updateMorphineEquivalence);
 });
 document.addEventListener('DOMContentLoaded', updateMorphineEquivalence);
-

--- a/docs/index.html
+++ b/docs/index.html
@@ -87,7 +87,7 @@
                             </div>
                             <div class="col-md-4 col-12">
                                 <label for="SfentanylPct">Percentage (%):</label>
-                                <input type="number" class="form-control fentanyl-input" id="SfentanylPct" placeholder="Enter percentage">
+                                <input type="number" class="form-control fentanyl-input" id="SfentanylPct" placeholder="4% (Default)" value="4">
                             </div>
                             <div class="col-md-4 col-12">
                                 <label for="m6">MEQ:</label>


### PR DESCRIPTION
updated default settings for street fentanyl conversion
- landing page now has a default input of 4
- If input is removed from Percentage input box, default placeholder will be shown
- Users are able to override default percentage